### PR TITLE
Allow building on recent macOS versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CFLAGS := -I . -I /usr/include/SDL2
 UNAME := $(shell uname -s)
 
 ifeq ($(UNAME),Darwin)
-	CFLAGS += -I /Library/Frameworks/SDL2.framework/Headers -F /Library/Frameworks/ -framework SDL2
+	CFLAGS += -Wno-deprecated-declarations -I /Library/Frameworks/SDL2.framework/Headers -F /Library/Frameworks/ -framework SDL2
 else
 	LDFLAGS := -lSDL2
 endif


### PR DESCRIPTION
Allow building using the deprecated ucontext.h.

![image](https://user-images.githubusercontent.com/218067/151703627-45e6e073-4b0b-443f-bac0-6dbaf70445d2.png)
