### PR TITLE
Fix -Waddress-of-packed-member warning on gcc 12.1

### DIFF
--- a/si78c.c
+++ b/si78c.c
@@ -320,7 +320,7 @@ uint8_t        vram[7168];                            //  0x2400
 
 uint8_t        oob[49152];                            //  0x4000
 
-} __attribute  ((packed));
+} __attribute__((packed,aligned(__alignof__(unsigned int))));
 
 typedef struct Mem Mem;
 


### PR DESCRIPTION
The warning was on si78c.c: 704: "warning: converting a packed ‘Mem’ pointer (alignment 1) to a ‘unsigned int’ pointer (alignment 4) may result in an unaligned pointer value"